### PR TITLE
Change CHANGELOG.md to GitHub Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ Please, refer to [CONTRIBUTING](CONTRIBUTING.md)
 Open a new Issue following our issue template [ISSUE-TEMPLATE](ISSUE-TEMPLATE.md)
 
 # Changelog
-See our [CHANGELOG](CHANGELOG.md)
+See in [releases](https://github.com/mundipagg/opencart/releases)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ modman init
 modman clone https://github.com/mundipagg/opencart
 ```
 
-## Installer do OpenCart
+## OpenCart Installer
 Download the latest release and paste the directories inside your store webroot.
 For releases, refer to [releases](https://github.com/mundipagg/opencart/releases).
 


### PR DESCRIPTION
Besides display our releases, the GitHub Releases page must display our changelog.