### PR TITLE
Remove --dev from Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 before_script:
   - echo "USE mysql;\nUPDATE user SET password=PASSWORD('root') WHERE user='root';\nFLUSH PRIVILEGES;\n" | mysql -u root
   - composer self-update
-  - composer install --dev
+  - composer install
   - composer setup
 script:
   - composer test


### PR DESCRIPTION
**What?** The deprecated option "dev" is removed. Dev packages are installed by default now.