### PR TITLE
Fix add order history on order status change

### DIFF
--- a/admin/controller/extension/payment/mundipagg.php
+++ b/admin/controller/extension/payment/mundipagg.php
@@ -290,6 +290,12 @@ class ControllerExtensionPaymentMundipagg extends Controller
                 $this->session->data['error_warning'] = "Fail on $word charge";
             } else {
                 $order->createOrUpdateCharge($order_info, $charge);
+                $this->load->model('sale/mundipagg/order');
+                $this->model_sale_mundipagg_order->addOrderHistory(
+                    $order_id,
+                    $order->translateStatusFromMP($charge),
+                    "Charge $word. Amount: " . $this->request->post['charge_amount']
+                );
             }
         } catch (\Exception $e) {
             $this->session->data['error_warning'] = $e->getMessage();

--- a/admin/model/sale/mundipagg/order.php
+++ b/admin/model/sale/mundipagg/order.php
@@ -1,0 +1,15 @@
+<?php
+
+class ModelSaleMundipaggOrder extends Model
+{
+    public function addOrderHistory($order_id, $order_status_id, $comment = '', $notify = false, $override = false)
+    {
+        $sql = "INSERT INTO " . DB_PREFIX . "order_history SET " .
+            "order_id = '" . (int)$order_id . "', " .
+            "order_status_id = '" . (int)$order_status_id . "', " .
+            "notify = '" . (int)$notify . "', " .
+            "comment = '" . $this->db->escape($comment) . "', " .
+            "date_added = NOW()";
+        $this->db->query($sql);
+    }
+}

--- a/modman
+++ b/modman
@@ -4,6 +4,7 @@ admin/view/image/mundipagg/ admin/view/image/mundipagg/
 
 # model
 admin/model/extension/payment/mundipagg.php admin/model/extension/payment/mundipagg.php
+admin/model/sale/mundipagg/* admin/model/sale/mundipagg
 
 # view
 admin/view/template/extension/payment/* admin/view/template/extension/payment/

--- a/system/library/mundipagg/src/Controller/WebHook.php
+++ b/system/library/mundipagg/src/Controller/WebHook.php
@@ -108,7 +108,7 @@ class WebHook
     {
         $this->openCart->load->language('extension/payment/mundipagg');
         $language = $this->openCart->load->language('extension/payment/mundipagg');
-
+        $language = $language['order_history_update'];
         $amount = null;
 
         switch ($this->action) {
@@ -168,7 +168,8 @@ class WebHook
     {
         $this->openCart->load->language('extension/payment/mundipagg');
         $language = $this->openCart->load->language('extension/payment/mundipagg');
-        $mPOrderId = $this->data['code'];
+        $language = $language['order_history_update'];
+        $mPOrderId = $this->data['order']['id'];
 
         switch ($this->action) {
             case WebHookEnum::ACTION_PAID:

--- a/system/library/mundipagg/src/Model/WebHook.php
+++ b/system/library/mundipagg/src/Model/WebHook.php
@@ -24,11 +24,11 @@ class WebHook
     {
         $sql = 'SELECT `opencart_id` from `' .
             DB_PREFIX . 'mundipagg_order`' .
-            'WHERE `mundipagg_id` = `' . $mundiPaggOrderId . '`';
+            'WHERE `mundipagg_id` = "' . $mundiPaggOrderId . '"';
 
 
         $result = $this->openCart->db->query($sql);
-        return $result->row;
+        return end($result->row);
     }
 
     public function setOrderStatus($orderId, $statusId)
@@ -76,6 +76,11 @@ class WebHook
 
     public function getOpenCartOrderIdFromMundiPaggOrderId($mPOrderId)
     {
-        return 1;
+        $sql = 'SELECT `opencart_id` from `' .
+            DB_PREFIX . 'mundipagg_order`' .
+            'WHERE `mundipagg_id` = "' . $mPOrderId . '"';
+
+        $result = $this->openCart->db->query($sql);
+        return end($result->row);
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| What?         | 1 - Fixed add order history on cancel/capture on panel.
|                    | 2 - Fixed add order history on webhook receive.
| Why?          | 1 - To add order status change history.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
