### PR TITLE
Two creditcards are always saved

### DIFF
--- a/system/library/mundipagg/src/Controller/TwoCreditCards.php
+++ b/system/library/mundipagg/src/Controller/TwoCreditCards.php
@@ -174,10 +174,8 @@ class TwoCreditCards
 
     private function setSaveCreditCard()
     {
-//        $this->saveCreditCards[] = $this->details['save-credit-card-0'];
-        $this->saveCreditCards[] = true;
-//        $this->saveCreditCards[] = $this->details['save-credit-card-1'];
-        $this->saveCreditCards[] = true;
+        $this->saveCreditCards[] = $this->details['save-this-credit-card-1'] === 'on';
+        $this->saveCreditCards[] = $this->details['save-this-credit-card-2'] === 'on';
     }
 
     private function saveCreditCards($orderResponse)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| What?         | Two creditcards are always saved
| Why?          | The customer must decide whether or not save the cards.
| How?          | This option is not hardcoded anymore. 

#### Status
READY