### PR TITLE
#111 Fix empty order status

### DIFF
--- a/catalog/controller/extension/payment/mundipagg.php
+++ b/catalog/controller/extension/payment/mundipagg.php
@@ -68,6 +68,7 @@ class ControllerExtensionPaymentMundipagg extends Controller
         $this->load->language('extension/payment/mundipagg');
 
         $this->data['misc'] = $this->language->get('misc');
+        $this->data['order_statuses'] = $this->language->get('order_statuses');
         $this->setting = $this->model_setting_setting;
         $this->mundipaggModel = $this->model_extension_payment_mundipagg;
         $this->creditCardModel = $this->model_extension_payment_mundipagg_credit_card;
@@ -446,8 +447,10 @@ class ControllerExtensionPaymentMundipagg extends Controller
             $this->response->redirect($this->url->link('checkout/failure'));
         }
 
+        $orderComment = $this->data['order_statuses'][$response->status];
+
         $newOrder = $this->getOrder();
-        $newOrder->updateOrderStatus($orderStatus);
+        $newOrder->updateOrderStatus($orderStatus, $orderComment);
 
         $this->saveMPOrderId($response->id, $this->session->data['order_id']);
         $this->response->redirect($this->url->link('checkout/success', '', true));
@@ -505,7 +508,9 @@ class ControllerExtensionPaymentMundipagg extends Controller
             $this->response->redirect($this->url->link('checkout/failure'));
         }
 
-        $this->getOrder()->updateOrderStatus($orderStatus);
+        $orderComment = $this->data['order_statuses'][$response->status];
+
+        $this->getOrder()->updateOrderStatus($orderStatus, $orderComment);
         $this->saveMPOrderId($response->id, $this->session->data['order_id']);
         $this->response->redirect($this->url->link('checkout/success', '', true));
     }
@@ -593,8 +598,10 @@ class ControllerExtensionPaymentMundipagg extends Controller
             $this->response->redirect($this->url->link('checkout/failure', '', true));
         }
 
+        $orderComment = $this->data['order_statuses'][$response->status];
+
         $newOrder = $this->getOrder();
-        $newOrder->updateOrderStatus($orderStatus);
+        $newOrder->updateOrderStatus($orderStatus, $orderComment);
 
         $this->saveMPOrderId($response->id, $this->session->data['order_id']);
         $this->response->redirect($this->url->link('checkout/success', '', true));

--- a/catalog/language/en-gb/extension/payment/mundipagg.php
+++ b/catalog/language/en-gb/extension/payment/mundipagg.php
@@ -64,3 +64,10 @@ $_['saved_creditcard'] = [
     'last_four_digits' => 'Last four digits',
     'delete' => 'Delete'
 ];
+
+$_['order_statuses'] = [
+    'pending' => 'Order created',
+    'paid' => 'Order paid',
+    'canceled' => 'Order canceled',
+    'failed' => 'Order failed'
+];

--- a/catalog/language/pt-br/extension/payment/mundipagg.php
+++ b/catalog/language/pt-br/extension/payment/mundipagg.php
@@ -64,3 +64,10 @@ $_['saved_creditcard'] = [
     'last_four_digits' => 'Últimos quatro dígitos',
     'delete' => 'Excluir'
 ];
+
+$_['order_statuses'] = [
+    'pending' => 'Pedido criado',
+    'paid' => 'Pagamento efetuado',
+    'canceled' => 'Pedido cancelado',
+    'failed' => 'Falha no pagamento'
+];

--- a/system/library/mundipagg/src/Order.php
+++ b/system/library/mundipagg/src/Order.php
@@ -641,9 +641,10 @@ class Order
      * Update opencart order status with the mundipagg translated status
      *
      * @param mixed $orderStatus
+     * @param string $comment
      * @return void
      */
-    public function updateOrderStatus($orderStatus)
+    public function updateOrderStatus($orderStatus, $comment = '')
     {
         $this->openCart->load->model('extension/payment/mundipagg_order_processing');
         $model = $this->openCart->model_extension_payment_mundipagg_order_processing;
@@ -651,7 +652,7 @@ class Order
         $model->addOrderHistory(
             $this->openCart->session->data['order_id'],
             $orderStatus,
-            '',
+            $comment,
             true
         );
 


### PR DESCRIPTION
**Closes https://github.com/mundipagg/plug-team/issues/111**

| Questions     | Answers
| ------------- | -------------------------------------------------------
| What?         | Fix empty order status history
| Why?          | Improve status history
| How?          | Receive a new param in addOrderHistory()

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->


![image](https://user-images.githubusercontent.com/6605776/37991015-577869c2-31de-11e8-9d6e-5eecac401029.png)
